### PR TITLE
[Error Catching] Add form to collect student feedback on error logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+testing/
+Examples.ipynb
+errorLog.csv
+.ipynb_checkpoints/

--- a/d8error.py
+++ b/d8error.py
@@ -2,11 +2,19 @@ from IPython.core.display import display, HTML, Markdown
 import json
 import os.path
 import csv
+import ipywidgets as widgets
 
 class Announce:
+    """error index, serves as an id on the csv file"""
+    eindex = 0
+
     def __init__(self, etype, value):
+        self.eindex = Announce.eindex
+        Announce.eindex += 1
         self.etype = etype
         self.value = value
+        self.feedbackRating = 0
+        self.feedbackMSG = ""
         self.errorname = str(etype().__class__.__name__)
         with open("errorConfig.json", "r") as f:
             diction = json.load(f)
@@ -22,24 +30,33 @@ class Announce:
                 if (key in str(value)):
                     prewrittenMessge = True
             self.print = prewrittenMessge
-            
+
+        def writeRow(file):
+            """saves errors to errorLog.csv"""
+            fieldnames = ['index', 'errorType', 'errorMSG', 'feedbackRating', 'feedbackMSG']
+            writer = csv.DictWriter(file, fieldnames=fieldnames)
+            writer.writerow({"index": self.eindex,
+                            "errorType": self.errorname,
+                            "errorMSG": str(self.value),
+                            "feedbackRating": self.feedbackRating,
+                            "feedbackMSG": self.feedbackMSG})
+
         if not os.path.isfile("errorLog.csv"):
             with open('errorLog.csv', 'w', newline='') as f:
-                
-                fieldnames = ['errorType', 'errorMSG']
-                writer = csv.DictWriter(f, fieldnames=fieldnames)
-                writer.writerow({"errorType": self.errorname,"errorMSG": str(value)})
+                writeRow(f)
         else:
+            if Announce.eindex == 1:
+                with open("errorLog.csv", 'r') as f:
+                    for row in csv.reader(f):
+                        self.eindex = int(row[0])
+                    self.eindex += 1
+                    Announce.eindex = self.eindex + 1
             with open('errorLog.csv', 'a', newline='') as f:
-                
-                fieldnames = ['errorType', 'errorMSG']
-                writer = csv.DictWriter(f, fieldnames=fieldnames)
-                writer.writerow({"errorType": self.errorname,"errorMSG": str(value)})
-        
+                writeRow(f)
+    
     def tips(self):
         etype = self.etype
         value = self.value
-
         with open("errorConfig.json", "r") as f:
             diction = json.load(f)
         exceptionClass = diction.get(self.errorname)
@@ -65,7 +82,65 @@ class Announce:
     def default(self):
         display(Markdown("It seems we have a "+self.errorname+ ". " +self.errorname+ "s are usually because of:"))
     def feedback(self):
-        display(Markdown("Please fill out this quick survey to help us improve the the error feedback [Data 8 Error Feedback Survey](https://forms.gle/6UZQjwZmAxVDMsBR6)"))
+        def overwriteRow():
+            """rewrites the feedbackRating & feedbackMSG columns on errorLog.csv"""
+            with open("errorLog.csv", 'r') as f:
+                reader = csv.reader(f, delimiter=',')
+                lines = []
+                for line in reader:
+                    if line[0] == str(self.eindex):
+                        line[3] = self.feedbackRating
+                        line[4] = self.feedbackMSG
+                    lines.append(line)
+            with open("errorLog.csv", 'w', newline='') as f:
+                writer = csv.writer(f, delimiter=',')
+                writer.writerows(lines)
+
+        """create & label a dropdown menu"""
+        dropdown_label = widgets.Label(value="Was the message you saw useful?")
+        dropdown = widgets.Dropdown(options=[('', 0),
+                                             ('Extremely useful', 5),
+                                             ('Very useful', 4),
+                                             ('Somewhat useful', 3),
+                                             ('Slightly useful', 2),
+                                             ('Not at all useful', 1)],
+                                    value=0)
+        def handle_slider_change(change):
+            """on change: rewrites the feedbackRating in the CSV"""
+            self.feedbackRating = dropdown.value
+            overwriteRow()
+        dropdown.observe(handle_slider_change)
+
+        """create & label a textbox"""
+        textbox_label = widgets.Label(value="Any other feedback?")
+        textbox = widgets.Text(value="",
+                               placeholder="Press enter to submit.",
+                               layout=widgets.Layout(width='50%', margin='0px 8px 0px 0px', padding='0px'))
+        def submit_text(t):
+            """on textbox submit: remove other fields and replace with a thank you message"""
+            self.feedbackMSG = t.value
+            accordion.children = [widgets.Label(value="Thank you for your feedback!")]
+            overwriteRow()
+        textbox.on_submit(submit_text)
+
+        """create a submit button for the textbox"""
+        submit_button = widgets.Button(description="Submit",
+                                       layout=widgets.Layout(width='10%', min_width='80px'))
+        def on_btn_click(b):
+            """on button click: submits textbox and replaces other fields with a thank you message"""
+            submit_text(textbox)
+        submit_button.on_click(on_btn_click)
+        
+        """bundle together widgets for a cleaner output"""
+        dropdownBox = widgets.VBox([dropdown_label, dropdown])
+        submitBox = widgets.HBox([textbox, submit_button])
+        submitBox.layout.align_items = 'center'
+        textboxBox = widgets.VBox([textbox_label, submitBox])
+        output = widgets.VBox([dropdownBox, textboxBox])
+        accordion = widgets.Accordion([output])
+        accordion.set_title(0, '  Feedback Form')
+
+        display(accordion)
 
 def test_exception(self, etype, value, tb, tb_offset=None):
     try:
@@ -81,9 +156,3 @@ def test_exception(self, etype, value, tb, tb_offset=None):
         self.showtraceback((etype, value, tb), tb_offset=tb_offset)
     
 get_ipython().set_custom_exc((Exception,), test_exception)
-
-if not os.path.isfile("errorLog.csv"):
-    with open('errorLog.csv', 'w', newline='') as f:
-        fieldnames = ['errorType', 'errorMSG']
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
-#s


### PR DESCRIPTION
## **What's new in this PR?**
This PR adds an embedded feedback form for each error produced that relates to d8error.py. The feedback form asks:
1) Was the message you saw useful? [multiselect]
2) Any other feedback? [string]

Upon submission, this feedback data (rating, message) is logged in errorLog.csv along with its row index, corresponding error and error type. 
- The index helps track what line the error is logged on, since there is no easy way to track this in a CSV.
- If an error is outputted but no feedback is given by the student, the record will be written in errorLog.csv with a 0 for feedback rating and an empty string for the feedback message.
- Every time the student changes the feedback rating on the dropdown value, the error log will rewrite itself. (This is because there is no submit button for the dropdown menu, and in case the student does not add any further feedback.)
    - Feedback is rated on a scale of "not at all useful" (1) to "extremely useful" (5).
- Once additional feedback is submitted via the textbox (either by pressing enter or clicking the submit button), the feedback rating & message are written to the error log. Both the dropdown & textbox will disappear from view, as they cannot be changed anymore. A thank you message will display in their place.
- Students can choose to collapse the thank you message.

### **How to Review**
Open Examples.ipynb, run a code cell that produces an error, and input feedback. 
Check whether or not the feedback submitted is produced in errorLog.csv.

### **Related PRs**
N/A

### **Next steps**
Transition the error log data to live in a server instead of CSVs.

### **Screenshots**
![feedbackForm1](https://user-images.githubusercontent.com/57937407/139361906-78278f0f-dd19-4135-b441-2c390c87ef48.png)
![feedbackForm2](https://user-images.githubusercontent.com/57937407/139361909-f96ef7aa-4678-4827-b31e-1ede3eec679f.png)
![feedbackForm3](https://user-images.githubusercontent.com/57937407/139361910-7ef0c2cc-beae-4a44-baf5-c405d3d68d11.png)

**Note:** The text "or see the error message below" is now confusing due to the feedback form now being directly below. We think that writing something like "or see the error message below the feedback form" OR showing the traceback above the form is more helpful. 

CC: @kenny-chi @micahtyong 